### PR TITLE
Write out transcripts with corrected splice junctions

### DIFF
--- a/TranscriptClean.py
+++ b/TranscriptClean.py
@@ -726,6 +726,7 @@ def cleanNoncanonical(transcripts, annotatedJunctions, genome, n, spliceAnnot, o
                                              "Corrected", "NA"])
                         transcriptErrorLog.write(errorEntry + "\n")
                         currTranscript = temp_transcript
+                        transcripts[transcriptID] = currTranscript
                         Transcript2.addCorrected_NC_SJ(currTranscript)
                     #currTranscript.SEQ = currSeq
                     #currTranscript.CIGAR = currCIGAR


### PR DESCRIPTION
Hi,

I've attempted to use TranscriptClean to correct noncanonical splice junctions, but the sequences and cigar strings in the output remain the same as in the input. After stepping through the code, I believe it is because the call to `cleanNoncanonical` does not update the  transcript objects in the `noncanTranscripts` dictionary before they are written out.

https://github.com/dewyman/TranscriptClean/blob/71e7572d91bff5268d265824aee531b4292a9802/TranscriptClean.py#L163-L171

Note that the `cleanNoncanonical` function constructs a copy of the transcript object and updates its attributes with the corrected sequence and cigar string, but the original transcript in the dictionary is not replaced with the corrected transcript. (The `Transcript2.addCorrected_NC_SJ` function only logs the number of transcripts with a corrected splice junction.)

https://github.com/dewyman/TranscriptClean/blob/71e7572d91bff5268d265824aee531b4292a9802/TranscriptClean.py#L717-L729

I've changed the `cleanNoncanonical` function to replace each transcript in the dictionary after it's corrected.

Matt
