### PR TITLE
No module named "dstruct"

### DIFF
--- a/dstruct.py
+++ b/dstruct.py
@@ -1,0 +1,12 @@
+class Struct(dict):
+    """
+    Make a dict behave as a struct.
+
+    Example:
+    
+        test = Struct(a=1, b=2, c=3)
+
+    """
+    def __init__(self,**kw):
+        dict.__init__(self,kw)
+        self.__dict__ = self


### PR DESCRIPTION
Hey,

I noticed the release of TranscriptClean version 2 now in python3 and implemented multi threading, which is very nice, thank you.
However, I am getting the error "no module named "dstruct"". I am assuming this is the same dstruct.py from TALON, its just missing from the TranscriptClean repo.